### PR TITLE
refactor validate form

### DIFF
--- a/src/formik-validation.spec.ts
+++ b/src/formik-validation.spec.ts
@@ -925,7 +925,6 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -965,7 +964,6 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1008,7 +1006,6 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(validationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1050,7 +1047,6 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(validationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1099,7 +1095,6 @@ when adding one validator to a given nested field with kebap case
           expect(validationFn1).toHaveBeenCalled();
           expect(validationFn2).not.toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1148,7 +1143,6 @@ when adding one validator to a given nested field with kebap case
           expect(validationFn1).toHaveBeenCalled();
           expect(validationFn2).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1197,7 +1191,6 @@ when adding one validator to a given nested field with kebap case
           expect(validationFn1).toHaveBeenCalled();
           expect(validationFn2).not.toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
               type: '',
@@ -1288,7 +1281,6 @@ when adding one validator to a given nested field with kebap case
           expect(validationFn1).toHaveBeenCalled();
           expect(validationFn2).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({});
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION1: {
               type: '',
@@ -1346,12 +1338,10 @@ when adding one validator to a given nested field with kebap case
           expect(myFieldValidation).toHaveBeenCalled();
           expect(myRecordValidation).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'mymessageA',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'mymessageA',
           });
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
@@ -1404,12 +1394,10 @@ when adding one validator to a given nested field with kebap case
           expect(myFieldValidation).toHaveBeenCalled();
           expect(myRecordValidation).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: true,
-              message: 'mymessageA',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: true,
+            message: 'mymessageA',
           });
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
@@ -1463,12 +1451,10 @@ when adding one validator to a given nested field with kebap case
           expect(myFieldValidation).toHaveBeenCalled();
           expect(myRecordValidation).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'mymessageA',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'mymessageA',
           });
           expect(validationResult.recordErrors).toEqual({
             MY_RECORD_VALIDATION: {
@@ -1593,12 +1579,10 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'mymessage',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'mymessage',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1631,12 +1615,10 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'mymessage',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'mymessage',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1676,12 +1658,10 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'myoverriddenmessage',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'myoverriddenmessage',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1722,12 +1702,10 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'myoverriddenmessage',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'myoverriddenmessage',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1770,13 +1748,11 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message:
-                'whatever myoverriddenmessage custom-arg {"username":"whatever"}',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message:
+              'whatever myoverriddenmessage custom-arg {"username":"whatever"}',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1825,12 +1801,10 @@ when adding one validator to a given nested field with kebap case
           // Assert
           expect(mockValidationFn).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_TYPE',
-              succeeded: false,
-              message: 'received custom args fail true',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_TYPE',
+            succeeded: false,
+            message: 'received custom args fail true',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1951,12 +1925,10 @@ when adding two validators to a given field and first fails
           expect(mockValidationFn1).toHaveBeenCalled();
           expect(mockValidationFn2).not.toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_VALIDATOR_A',
-              succeeded: false,
-              message: 'mymessageA',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_VALIDATOR_A',
+            succeeded: false,
+            message: 'mymessageA',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -1995,12 +1967,10 @@ when adding two validators to a given field and second fails
           expect(mockValidationFn1).toHaveBeenCalled();
           expect(mockValidationFn2).toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_VALIDATOR_B',
-              succeeded: false,
-              message: 'mymessageB',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_VALIDATOR_B',
+            succeeded: false,
+            message: 'mymessageB',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();
@@ -2039,12 +2009,10 @@ when adding two validators to a given field fails and second fails
           expect(mockValidationFn1).toHaveBeenCalled();
           expect(mockValidationFn2).not.toHaveBeenCalled();
           expect(validationResult.succeeded).toBeFalsy();
-          expect(validationResult.fieldErrors).toEqual({
-            username: {
-              type: 'MY_VALIDATOR_A',
-              succeeded: false,
-              message: 'mymessageA',
-            },
+          expect(validationResult.username).toEqual({
+            type: 'MY_VALIDATOR_A',
+            succeeded: false,
+            message: 'mymessageA',
           });
           expect(validationResult.recordErrors).toEqual({});
           done();

--- a/src/formik-validation.ts
+++ b/src/formik-validation.ts
@@ -46,7 +46,10 @@ export class FormikValidation {
   public validateForm(values: any): Promise<FormValidationResult> {
     return this.formValidation.validateForm(values).then(result => {
       if (!result.succeeded) {
-        throw result;
+        throw {
+          ...result.fieldErrors,
+          recordErrors: result.recordErrors,
+        };
       }
 
       return null;


### PR DESCRIPTION
Simplified result for formValidation in formik:

```javascript
            throw {
              ...result.fieldErrors,
              recordErrors: result.recordErrors
            };
```
